### PR TITLE
build: support mbedtls

### DIFF
--- a/autobuild/zflist.sh
+++ b/autobuild/zflist.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 set -ex
 
-makeopts="-j 12"
+makeopts="-j $(grep ^flags /proc/cpuinfo | wc -l)"
 
 dependencies() {
     apt-get update
 
     apt-get install -y build-essential git libsnappy-dev libz-dev \
         libtar-dev libb2-dev autoconf libtool libjansson-dev \
-        libhiredis-dev libsqlite3-dev libssl-dev
+        libhiredis-dev libsqlite3-dev libssl-dev libmbedtls-dev
 }
 
 libcurl() {
@@ -21,7 +21,7 @@ libcurl() {
         --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher \
         --disable-manual --disable-libcurl-option --disable-sspi --disable-ntlm-wb --without-brotli --without-librtmp --without-winidn \
         --disable-threaded-resolver \
-        --with-openssl
+        --without-openssl --with-mbedtls
 
     make ${makeopts}
     make install
@@ -53,7 +53,7 @@ zeroflist() {
     popd
 
     pushd zflist
-    make production
+    make production-mbed
     popd
 
     cp zflist/zflist /tmp/zflist

--- a/autobuild/zflist.sh
+++ b/autobuild/zflist.sh
@@ -21,7 +21,7 @@ libcurl() {
         --disable-telnet --disable-tftp --disable-pop3 --disable-imap --disable-smb --disable-smtp --disable-gopher \
         --disable-manual --disable-libcurl-option --disable-sspi --disable-ntlm-wb --without-brotli --without-librtmp --without-winidn \
         --disable-threaded-resolver \
-        --without-openssl --with-mbedtls
+        --without-ssl --with-mbedtls
 
     make ${makeopts}
     make install
@@ -45,7 +45,7 @@ capnp() {
 }
 
 zeroflist() {
-    git clone -b development-v2 https://github.com/threefoldtech/0-flist
+    git clone -b development-v2-mbed https://github.com/threefoldtech/0-flist
     pushd 0-flist
 
     pushd libflist

--- a/autobuild/zflist.sh
+++ b/autobuild/zflist.sh
@@ -45,7 +45,7 @@ capnp() {
 }
 
 zeroflist() {
-    git clone -b development-v2-mbed https://github.com/threefoldtech/0-flist
+    git clone -b development-v2-mbedtls https://github.com/threefoldtech/0-flist
     pushd 0-flist
 
     pushd libflist

--- a/zflist/Makefile
+++ b/zflist/Makefile
@@ -18,6 +18,11 @@ production: CFLAGS += -std=c99 -W -Wall -O2 -I../libflist
 production: LDFLAGS += -static-libstdc++ -static-libgcc -Wl,-Bstatic -L../libflist -lflist -pthread -ltar -lb2 -lz -lcapnp_c -lsnappy -ljansson -lhiredis -fopenmp -lcurl -lssl -lcrypto -lsqlite3 -Wl,-Bdynamic -pthread -lrt -ldl
 production: $(EXEC)
 
+# embeded, static without debug
+production-mbed: CFLAGS += -std=c99 -W -Wall -O2 -I../libflist
+production-mbed: LDFLAGS += -static-libstdc++ -static-libgcc -Wl,-Bstatic -L../libflist -lflist -pthread -ltar -lb2 -lz -lcapnp_c -lsnappy -ljansson -lhiredis -fopenmp -lcurl -lmbedcrypto -lmbedx509 -lmbedtls -lmbedcrypto -lmbedx509 -lmbedtls -lsqlite3 -Wl,-Bdynamic -pthread -lrt -ldl
+production-mbed: $(EXEC)
+
 # shared without debug
 release: CFLAGS += -std=c99 -W -Wall -O2 -I../libflist
 release: LDFLAGS += -pthread -ltar -lb2 -lz -lcapnp_c -lsnappy -ljansson -lhiredis -lcurl -fopenmp -lsqlite3 -L../libflist -lflist


### PR DESCRIPTION
Change default autobuild release to use `mbedtls` as tls backend.
This reduce binary size and dependencies by half the size and increase security.